### PR TITLE
Create rubocop.yml

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -23,14 +23,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # If running on a self-hosted runner, check it meets the requirements
     # listed at https://github.com/ruby/setup-ruby#using-self-hosted-runners
     - name: Set up Ruby
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1.263.0
       with:
-        ruby-version: 2.6
+        ruby-version: '2.6.7'
+        bundler-cache: true
 
     # This step is not necessary if you add the gem to your Gemfile
     - name: Install Code Scanning integration

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,8 +12,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
-  schedule:
-    - cron: '39 15 * * 2'
 
 jobs:
   rubocop:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1.263.0
       with:
-        ruby-version: '2.6.7'
+        ruby-version: '3.1.0'
         bundler-cache: true
 
     # This step is not necessary if you add the gem to your Gemfile

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,6 +13,10 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   rubocop:
     runs-on: ubuntu-latest
@@ -38,14 +42,8 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
-    - name: Rubocop run
-      run: |
-        bash -c "
-          bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
-          [[ $? -ne 2 ]]
-        "
-
-    - name: Upload Sarif output
-      uses: github/codeql-action/upload-sarif@v3
+    - uses: reviewdog/action-rubocop@b6d5e953a5fc0bf3ab65254e77730ea2174d6d6d # v2.22.0
       with:
-        sarif_file: rubocop.sarif
+        reporter: github-pr-review # Default is github-pr-check
+        skip_install: true
+        use_bundler: true

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,52 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# pulled from repo
+name: "Rubocop"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '39 15 * * 2'
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # If running on a self-hosted runner, check it meets the requirements
+    # listed at https://github.com/ruby/setup-ruby#using-self-hosted-runners
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      with:
+        ruby-version: 2.6
+
+    # This step is not necessary if you add the gem to your Gemfile
+    - name: Install Code Scanning integration
+      run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
+
+    - name: Install dependencies
+      run: bundle install
+
+    - name: Rubocop run
+      run: |
+        bash -c "
+          bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
+          [[ $? -ne 2 ]]
+        "
+
+    - name: Upload Sarif output
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: rubocop.sarif

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -35,13 +35,6 @@ jobs:
         ruby-version: '3.2.0'
         bundler-cache: true
 
-    # This step is not necessary if you add the gem to your Gemfile
-    - name: Install Code Scanning integration
-      run: bundle add code-scanning-rubocop --version 0.3.0 --skip-install
-
-    - name: Install dependencies
-      run: bundle install
-
     - uses: reviewdog/action-rubocop@b6d5e953a5fc0bf3ab65254e77730ea2174d6d6d # v2.22.0
       with:
         reporter: github-pr-review # Default is github-pr-check

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1.263.0
       with:
-        ruby-version: '3.1.0'
+        ruby-version: '3.2.0'
         bundler-cache: true
 
     # This step is not necessary if you add the gem to your Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ gem 'activerecord'
 gem 'pg'
 
 group :development, :test do
+  gem 'rubocop'
   gem 'byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
     minitest (5.25.5)
     nio4r (2.7.4)
     pg (1.6.2-x64-mingw-ucrt)
+    pg (1.6.2-x86_64-linux)
     puma (7.0.4)
       nio4r (~> 2.0)
     rack (3.2.1)
@@ -48,6 +49,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   activerecord

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
@@ -30,21 +31,50 @@ GEM
     erb (5.0.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    json (2.15.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     logger (1.7.0)
     minitest (5.25.5)
     nio4r (2.7.4)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
     pg (1.6.2-x64-mingw-ucrt)
     pg (1.6.2-x86_64-linux)
+    prism (1.5.1)
     puma (7.0.4)
       nio4r (~> 2.0)
+    racc (1.8.1)
     rack (3.2.1)
     rackup (2.2.1)
       rack (>= 3)
+    rainbow (3.1.1)
+    regexp_parser (2.11.3)
+    rubocop (1.81.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.47.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     tilt (2.6.1)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
     uri (1.0.3)
 
 PLATFORMS
@@ -59,6 +89,7 @@ DEPENDENCIES
   puma
   rack
   rackup
+  rubocop
   tilt
 
 BUNDLED WITH


### PR DESCRIPTION
This PR is about adding a github workflow which install rubocop gem. 
ref: https://github.com/rubocop/rubocop

> RuboCop is a Ruby static code analyzer (a.k.a. linter) and code formatter. Out of the box it will enforce many of the guidelines outlined in the community [Ruby Style Guide](https://rubystyle.guide/). Apart from reporting the problems discovered in your code, RuboCop can also automatically fix many of them for you.