### PR TITLE
Create Base_Controller

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -40,7 +40,3 @@ jobs:
         reporter: github-pr-review # Default is github-pr-check
         skip_install: true
         use_bundler: true
-
-rubocop:
-  Layout/EndOfLine:
-    EnforcedStyle: crlf

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -40,3 +40,7 @@ jobs:
         reporter: github-pr-review # Default is github-pr-check
         skip_install: true
         use_bundler: true
+
+rubocop:
+  Layout/EndOfLine:
+    EnforcedStyle: crlf

--- a/lib/frack.rb
+++ b/lib/frack.rb
@@ -11,4 +11,5 @@ require 'pg'
 # Frack web framework module
 module Frack
   autoload :Router, 'frack/router'
+  autoload :BaseController, 'frack/base_controller'
 end

--- a/lib/frack/base_controller.rb
+++ b/lib/frack/base_controller.rb
@@ -6,5 +6,11 @@ module Frack
       @request = Rack::Request.new(env)
       @flash_message = request.session&.delete('flash')
     end
+
+    def render(view)
+      render_template('layouts/application') do
+        render_template(view)
+      end 
+    end
   end
 end

--- a/lib/frack/base_controller.rb
+++ b/lib/frack/base_controller.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module Frack
+  # Base controller class that provides common functionality for all controllers
   class BaseController
     attr_reader :request, :session, :current_user
 
@@ -10,11 +13,11 @@ module Frack
     def render(view)
       render_template('layouts/application') do
         render_template(view)
-      end 
+      end
     end
 
     def render_template(path, &block)
-        Tilt.new(file(path)).render(self, &block)
+      Tilt.new(file(path)).render(self, &block)
     end
 
     def file(path)

--- a/lib/frack/base_controller.rb
+++ b/lib/frack/base_controller.rb
@@ -1,0 +1,10 @@
+module Frack
+  class BaseController
+    attr_reader :request, :session, :current_user
+
+    def initialize(env)
+      @request = Rack::Request.new(env)
+      @flash_message = request.session&.delete('flash')
+    end
+  end
+end

--- a/lib/frack/base_controller.rb
+++ b/lib/frack/base_controller.rb
@@ -12,5 +12,9 @@ module Frack
         render_template(view)
       end 
     end
+
+    def render_template(path, &block)
+        Tilt.new(file(path)).render(self, &block)
+    end
   end
 end

--- a/lib/frack/base_controller.rb
+++ b/lib/frack/base_controller.rb
@@ -16,5 +16,9 @@ module Frack
     def render_template(path, &block)
         Tilt.new(file(path)).render(self, &block)
     end
+
+    def file(path)
+      Dir[File.join('app', 'views', "#{path}.html.*")].first
+    end
   end
 end


### PR DESCRIPTION
This PR creates Frack::BaseController, a foundation class designed to be inherited by all other controllers in the application, encapsulating common logic for handling requests and rendering views.