### PR TITLE
Fix NameError in app_config.rb

### DIFF
--- a/config/app_config.rb
+++ b/config/app_config.rb
@@ -19,6 +19,7 @@ module AppConfig
   end
 
   def self.setup_mail
+    smtp_settings = self.smtp_settings
     Mail.defaults do
       delivery_method :smtp, smtp_settings
     end


### PR DESCRIPTION
Fix the NameError in app_config.rb by placing the configuration variable in the correct scope of the block.